### PR TITLE
fix : member 정보 수정 오류 해결

### DIFF
--- a/src/component/popup/EditUserInfo.js
+++ b/src/component/popup/EditUserInfo.js
@@ -66,6 +66,7 @@ const EditUserInfo = ({ userInfo, onClose }) => {
           memSex: sex,
           memBirth: birth,
           memAddr: addr,
+          memType : userInfo.memType
         },
         { withCredentials: true }
       )


### PR DESCRIPTION
fix : member 정보 수정 오류 해결

member 정보 수정 시 memType을 지정하고 있지 않아 기본값인 0값으로 들어감

따라서 backend 세션 인가정보 검증과정에서 유효하지 않은 세션으로 판단됨